### PR TITLE
Bump rubocop version

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,1 +1,5 @@
 fail_on_violations: true
+
+rubocop:
+  version: 1.22.1
+  config_file: .rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+Lint/ScriptPermission:
+  Enabled: false


### PR DESCRIPTION
Bumping rubocop version for easy local testing.
Default hound rubocop version works up to ruby 2.7.
More likely newcomers will have ruby 3+
Disabling `Lint/ScriptPermission` because if fails on file with granted permission.